### PR TITLE
Update the Astropy version as the old one no longer works due to the older numpy version.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         'attrs>=19.0.0',
         'numpy>=1.16.0',
         'pandas>=0.24.0',
-        'astropy>=3.2.0',
+        'astropy>=7.0.1',
     ],
     tests_require=[
         'flake8>=3.7.0',

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md") as fp:
 
 setup(
     name='TLE-tools',
-    version='1.0.0',
+    version='1.0.1',
     description='Library to work with two-line element set files',
     license='MIT',
     author='Spire SOS Team',


### PR DESCRIPTION
Be aware that this also updates the required python version requirement to 3.11. 